### PR TITLE
feat: jams support

### DIFF
--- a/case/case2.jams
+++ b/case/case2.jams
@@ -1,0 +1,5 @@
+{
+  func adder
+  args [1 2]
+  want ["" 3]
+}

--- a/casetest.js
+++ b/casetest.js
@@ -3,16 +3,6 @@ import { readdirSync, readFileSync } from 'fs'
 import path from 'path'
 import { jams } from 'jams.js/jams.js'
 
-const fileParserHandler = {
-    json: function (data) {
-        return JSON.parse(data)
-    },
-    jams: function (data) {
-        // Convert `data` type from Buffer to String
-        return jams(data.toString())
-    }
-}
-
 const clean = (ext) => (String(ext).substring(1))
 
 export function casetest(dir, f) {
@@ -21,7 +11,18 @@ export function casetest(dir, f) {
         const filepath = path.resolve(path.join(process.cwd(), dir, file))
         const ext = clean(path.extname(filepath))
         const data = readFileSync(filepath) // TODO os.path
-        const obj = fileParserHandler[ext](data)
+
+        let obj
+
+        if (ext === 'json') {
+            obj = JSON.parse(data)
+        } else if (ext === 'jams') {
+            // Convert `data` type from Buffer to String
+            obj = jams(data.toString())
+        } else {
+            throw new Error('Unhandled filetype.')
+        }
+
         test(`file ${file}\nnote ${obj.note}`, t=>{
             t.ok(obj.func, 'no test func')
             t.ok(obj.args, 'no test args')

--- a/example.js
+++ b/example.js
@@ -1,17 +1,12 @@
 import { casetest } from './casetest.js'
 
 const lib = {}
-lib.adder =(a,b)=> [0, a+b] // result type
-
-const argsConverter = (s) => {
-    const n = Number(s)
-    return isFinite(n) && !isNaN(n) ? n : s
-}
+lib.adder =(a,b)=> [0, Number(a) + Number(b)] // result type
 
 casetest('./case', (t, {func,args,want})=>{
     // map it onto your lib
     // e.g. fromHex
-    let [err, ret] = lib[func](...args.map(argsConverter))
+    let [err, ret] = lib[func](...args)
     t.ok(!err)
     t.equal(ret, want[1])
 })

--- a/example.js
+++ b/example.js
@@ -3,11 +3,15 @@ import { casetest } from './casetest.js'
 const lib = {}
 lib.adder =(a,b)=> [0, a+b] // result type
 
+const argsConverter = (s) => {
+    const n = Number(s)
+    return isFinite(n) ? n : s
+}
 
 casetest('./case', (t, {func,args,want})=>{
     // map it onto your lib
     // e.g. fromHex
-    let [err, ret] = lib[func](...args)
+    let [err, ret] = lib[func](...args.map(argsConverter))
     t.ok(!err)
     t.equal(ret, want[1])
 })

--- a/example.js
+++ b/example.js
@@ -5,7 +5,7 @@ lib.adder =(a,b)=> [0, a+b] // result type
 
 const argsConverter = (s) => {
     const n = Number(s)
-    return isFinite(n) ? n : s
+    return isFinite(n) && !isNaN(n) ? n : s
 }
 
 casetest('./case', (t, {func,args,want})=>{

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "type": "module",
     "version": "0.0.3",
     "dependencies": {
+        "jams.js": "^0.0.5",
         "tapzero": "^0.6.1"
     }
 }


### PR DESCRIPTION
Closes issue #1 by integrating jams.js.

This PR is a draft because of the `argsConverter` found in `example.js`. Since jams returns strings for all values, there are two initial routes: 
1. Developers either need to ensure `type x` by converting jams returned values from `type string` to `type x`
2. jams.js returns a number when `str`.`isFinite` is `true` and `str`.`isNaN` is `false`.

jams return object:

```js
// current (option 1 maintains this)
{ func: 'adder', args: [ '1', '2' ], want: [ '""', '3' ] }

// JSON.parse
{ func: 'adder', args: [ 1, 2 ], want: [ '', 3 ] }
```
